### PR TITLE
Fix issue with the badge on firefox and replace faulty port within the example env file.

### DIFF
--- a/api/badge/badge.go
+++ b/api/badge/badge.go
@@ -59,6 +59,8 @@ func GenerateBadge(label, count, color, leftBgColor, rightBgColor, border string
 			return buf.WriteString(leftBgColor)
 		case "rightBgColor":
 			return buf.WriteString(rightBgColor)
+		case "rectWidth":
+			return buf.WriteString(rectWidth)
 		case "border": 
 			return buf.WriteString(border)
 		}

--- a/api/prisma/.env.example
+++ b/api/prisma/.env.example
@@ -1,1 +1,1 @@
-DATABASE_URL=mysql://hits:hits@127.0.0.1:5432/hitsdb
+DATABASE_URL=mysql://hits:hits@127.0.0.1:3306/hitsdb


### PR DESCRIPTION
## Fix Badge squeeze issue on Firefox.
<img width="176" alt="image" src="https://user-images.githubusercontent.com/21298625/153053033-d618cb87-7cea-40b4-936d-4de67f966b8c.png">
The shown image was the one displayed on Github for alii on the firefox browser.  
It seams to come from the `p > a > img` nesting and or some style property set by githubs markdown renderer.
The fix was to correctly set the width property on the svg in order to let firefox render the correct dimensions.

Here the Code which was used to reproduce the issue(**Note:** Replace the api port with the one you are using):
```html
<html>
	<head>
		<style type="text/css">
			a {
				box-sizing: border-box;
			}
		</style>
	</head>
	<body>
		<p>
			<a
				href="http://127.0.0.1:3303/v1/hits?url=https%3A%2F%2Fgithub.com%2Falii&bgRight=FAA0A0"
			>
				<img
					src="http://127.0.0.1:3303/v1/hits?url=https%3A%2F%2Fgithub.com%2Falii&bgRight=FAA0A0"
					style="max-width: 100%"
					width="100"
					height="20"
				/>
			</a>
		</p>
	</body>
</html>
```

## Fix wrong environment file port
The port set in the example env file seamed to be a redis port, this caused a issue where when copied the database code generate step would fail due to the wrong port.
This simply replaces the port with the correct one making a simple copy work. 