### PR TITLE
fix: badge overflow

### DIFF
--- a/api/badge/badge.go
+++ b/api/badge/badge.go
@@ -21,13 +21,13 @@ var badgeSVG = utils.Trim(`
 		<rect width="100" height="20" rx="{{border}}" fill="#fff"/>
 	</clipPath>
 	<g clip-path="url(#r)">
-		<rect width="69" height="20" fill="{{leftBgColor}}"/>
-		<rect x="69" width="31" height="20" fill="{{rightBgColor}}"/>
+		<rect width="38" height="20" fill="{{leftBgColor}}"/>
+		<rect x="38" width="62" height="20" fill="{{rightBgColor}}"/>
 		<rect width="{{rectWidth}}" height="20" fill="url(#s)"/>
 	</g>
 	<g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="110">
-		<text x="355" y="140" transform="scale(.1)" fill="{{color}}">{{label}}</text>
-		<text x="835" y="140" transform="scale(.1)" fill="{{color}}">{{count}}</text>
+		<text x="195" y="140" transform="scale(.1)" fill="{{color}}">{{label}}</text>
+		<text x="695" y="140" transform="scale(.1)" fill="{{color}}">{{count}}</text>
 	</g>
 </svg>
 `)


### PR DESCRIPTION
The most heated link from `hits.link` is https://github.com/aidenybai/million, which has more than 65000 hits already:

<img width="403" alt="image" src="https://user-images.githubusercontent.com/40715044/185845829-79346ba1-655b-4fcf-aac1-41517f713e6d.png">

The hit count is so large that it overflows. The PR fixes that:

<img width="403" alt="image" src="https://user-images.githubusercontent.com/40715044/185846852-122a18b4-2e82-4eb1-af7f-66b644b4f479.png">

<img width="407" alt="image" src="https://user-images.githubusercontent.com/40715044/185846933-163ad243-3fe0-4f7e-a523-013d4fd81b16.png">



